### PR TITLE
Fix intermittent failing tests in backtracking algorithm

### DIFF
--- a/algos/backtracking.go
+++ b/algos/backtracking.go
@@ -29,8 +29,8 @@ func (bt *BackTracking) Generate() error {
 //doWork: the recrusive backtracking algorithm
 func (bt *BackTracking) doWork(x, y int) {
 	d := gaze.Direction{}
-	gaze.Shuffle(directions)
-	for _, direction := range directions {
+	dirs := shuffledDirections()
+	for _, direction := range dirs {
 		dir := direction.(gaze.FlagPosition)
 		var nextX int = x + d.XDirection(dir)
 		var nextY int = y + d.YDirection(dir)
@@ -41,4 +41,11 @@ func (bt *BackTracking) doWork(x, y int) {
 			bt.doWork(nextX, nextY)
 		}
 	}
+}
+
+func shuffledDirections() []interface{} {
+	dirs := make([]interface{}, len(directions))
+	copy(dirs, directions)
+	gaze.Shuffle(dirs)
+	return dirs
 }

--- a/algos/backtracking_test.go
+++ b/algos/backtracking_test.go
@@ -7,7 +7,6 @@ import (
 )
 
 func TestBackTrakcingAlgo_Generate_AllCellsVisited(t *testing.T) {
-	t.Skip("skipping this test for now")
 	k := NewBackTracking(10, 10)
 	k.Generate()
 	for i := uint16(0); i < k.Board.Width; i++ {


### PR DESCRIPTION
The directions were being shuffled in each call to doWork
but this was being called recursively which was shuffling
the directions while they were being looped over.

The fix was to make new set of shuffled directions for each
call to doWork.