### PR TITLE
Outputing triangular in console

### DIFF
--- a/board_tri.go
+++ b/board_tri.go
@@ -134,40 +134,122 @@ func (b *BoardTri) Break2Walls(c *Cell, idx int) {
 	}
 }
 
-func (b *BoardTri) Write(writer io.Writer) {
+func (b *BoardTri) Write3a(writer io.Writer) {
 	for h := uint16(0); h < b.Height; h++ {
-		//left border
-		c0 := b.Cells[h][0]
-		if c0.IsSet(TRIANGLE_UP) {
-			writer.Write([]byte("∕"))
-		} else {
-			writer.Write([]byte("∖"))
-		}
-
 		for w := uint16(0); w < b.Width; w++ {
 			c := b.Cells[h][w]
 			if c.IsSet(TRIANGLE_UP) {
-				if c.IsSet(SOUTH) {
-					writer.Write([]byte("⎯"))
+				writer.Write([]byte("∆"))
+			} else {
+				writer.Write([]byte("∇"))
+			}
+		}
+		writer.Write([]byte("\n"))
+	}
+}
+
+func (b *BoardTri) Write(writer io.Writer) {
+	for h := uint16(0); h < b.Height; h++ {
+		//left border
+		/*
+			c0 := b.Cells[h][0]
+			if c0.IsSet(TRIANGLE_UP) {
+				writer.Write([]byte("∕"))
+			} else {
+				writer.Write([]byte("∖"))
+			}
+		*/
+
+		//first pass
+		for w := uint16(0); w < b.Width; w++ {
+			c := b.Cells[h][w]
+
+			if c.IsSet(TRIANGLE_UP) {
+				if w == 0 {
+					if c.IsSet(WEST) {
+						writer.Write([]byte(" /"))
+					} else {
+						writer.Write([]byte("  "))
+					}
+				} else {
+					if c.IsSet(WEST) {
+						writer.Write([]byte("/"))
+					} else {
+						writer.Write([]byte(" "))
+					}
+				}
+
+				if c.IsSet(EAST) {
+					writer.Write([]byte("\\"))
 				} else {
 					writer.Write([]byte(" "))
 				}
 			} else {
+				//triangle pointing down
+				if c.IsSet(WEST) {
+					writer.Write([]byte("\\"))
+				} else {
+					writer.Write([]byte(" "))
+				}
+
 				if c.IsSet(NORTH) {
-					writer.Write([]byte("⎺"))
+					writer.Write([]byte("--"))
+				} else {
+					writer.Write([]byte("  "))
+				}
+
+				if c.IsSet(EAST) {
+					writer.Write([]byte("/"))
 				} else {
 					writer.Write([]byte(" "))
 				}
 			}
+		}
+		writer.Write([]byte("\n"))
 
-			if c.IsSet(EAST) {
-				if c.IsSet(TRIANGLE_UP) {
-					writer.Write([]byte("∖"))
+		//2nd pass
+		for w := uint16(0); w < b.Width; w++ {
+			c := b.Cells[h][w]
+
+			if c.IsSet(TRIANGLE_UP) {
+				if c.IsSet(WEST) {
+					writer.Write([]byte("/"))
 				} else {
-					writer.Write([]byte("∕"))
+					writer.Write([]byte(" "))
+				}
+
+				if c.IsSet(SOUTH) {
+					writer.Write([]byte("__"))
+				} else {
+					writer.Write([]byte("  "))
+				}
+
+				if c.IsSet(EAST) {
+					writer.Write([]byte("\\"))
+				} else {
+					writer.Write([]byte(" "))
 				}
 			} else {
-				writer.Write([]byte(" "))
+				//triangle pointing down
+				if w == 0 {
+					if c.IsSet(WEST) {
+						writer.Write([]byte(" \\"))
+					} else {
+						writer.Write([]byte("  "))
+					}
+				} else {
+					if c.IsSet(WEST) {
+						writer.Write([]byte("\\"))
+					} else {
+						writer.Write([]byte(" "))
+					}
+				}
+
+				if c.IsSet(EAST) {
+					writer.Write([]byte("/"))
+				} else {
+					writer.Write([]byte(" "))
+				}
 			}
 		}
 		writer.Write([]byte("\n"))


### PR DESCRIPTION
It's tough to represent a triangle using ascii, we could do `\/` and `/\` to show the northern and southern walls are broken thru, but to show the broken wall of west & east `_\` `/_` looks slightly out of sync, and the resulting image is not as pretty.

After trying with various shapes using ascii and utf-8 characters, I settle for this by drawing out 2 rows for a singe triangle.
```
 /\
/__\
```
Thus a 5x5 would be:
```
 /\\--//\\--//\
/__\\//__\\//__\
\--//\\--//\\--/
 \//__\\//__\\/
 /\\--//\\--//\
/__\\//__\\//__\
\--//\\--//\\--/
 \//__\\//__\\/
 /\\--//\\--//\
/__\\//__\\//__\
```
The resulting maze looks like this:
```
 /  --    --  \
/__    __      \
\--    --//    /
 \      //    /
 /    //    //\
/    //    //  \
\    \\        /
 \    \\      /
 /            \
/__    __    __\
```

Related issue: #5 

The borders on the very top and very bottom would also need to be drawn out to enclose the maze (next).